### PR TITLE
Update clippy action to avoid unknown workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         args: --all -- --check
 
     - name: Clippy
-      uses: actions-rs/clippy-check@v1
+      uses: brace-rs/clippy-check@b75a09651cc90c3921c41888815fe6a7a0b0adae
       with:
         args: --all -- -D warnings
         name: Lint / Results


### PR DESCRIPTION
The `actions-rs/clippy-check` action, when executed during a pull request workflow, will create checks on the merge commit instead of the pushed commit which causes the results to appear under an unknown workflow. This temporarily switches the action until the fix is merged.