### PR TITLE
Add development mode for autoreloading

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,6 +11,26 @@ dependencies = [
   "clippy",
 ]
 
+[tasks.run]
+script = [
+  "cargo run --manifest-path crates/brace-cms/Cargo.toml",
+]
+
+[tasks.run-dev]
+script = [
+  "systemfd --no-pid -s http::3000 -- cargo watch -x 'run --manifest-path crates/brace-cms/Cargo.toml --features dev'",
+]
+dependencies = [
+  "install-cargo-watch",
+  "install-systemfd",
+]
+
+[tasks.install-cargo-watch]
+install_crate = { crate_name = "cargo-watch", binary = "cargo-watch", test_arg = "--help" }
+
+[tasks.install-systemfd]
+install_crate = { crate_name = "systemfd", binary = "systemfd", test_arg = "--help" }
+
 [tasks.pre-git-commit]
 dependencies = [
   "lint",

--- a/crates/brace-cms/Cargo.toml
+++ b/crates/brace-cms/Cargo.toml
@@ -10,10 +10,15 @@ edition = "2018"
 [lib]
 path = "src/lib/lib.rs"
 
+[features]
+default = []
+dev = ["listenfd"]
+
 [dependencies]
 actix-rt = "1.0"
 brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", features = ["toml"], default_features = false }
 brace-web = { git = "https://github.com/brace-rs/brace-web", rev = "dd0cee2e916553594acb8270632b5727474db01f" }
+listenfd = { version = "0.3", optional = true }
 
 [dev-dependencies]
 assert_cmd = "1.0"


### PR DESCRIPTION
This adds a development mode that, once enabled with the `dev` feature, will integrate with `systemfd` to allow the server to automatically reload without dropping requests. This binds to a separate port than that specified in the configuration file.