### PR TITLE
Add logging with support for stdout, stderr and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+*.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
   "crates/brace-cms",
+  "crates/brace-cms-log",
 ]

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,7 @@
 [server]
 host = "127.0.0.1"
 port = 8080
+
+[log]
+level = "info"
+output = "stdout"

--- a/crates/brace-cms-log/Cargo.toml
+++ b/crates/brace-cms-log/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "brace-cms-log"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "The logging component of the brace-cms project."
+repository = "https://github.com/brace-rs/brace-cms"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]
+brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", default_features = false }
+chrono = "0.4"
+fern = { version = "0.6", features = ["colored"] }
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/brace-cms-log/src/level.rs
+++ b/crates/brace-cms-log/src/level.rs
@@ -1,0 +1,47 @@
+use std::fmt::{self, Display};
+
+use log::LevelFilter;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Level {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Default for Level {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
+impl Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Off => write!(f, "off"),
+            Self::Error => write!(f, "error"),
+            Self::Warn => write!(f, "warn"),
+            Self::Info => write!(f, "info"),
+            Self::Debug => write!(f, "debug"),
+            Self::Trace => write!(f, "trace"),
+        }
+    }
+}
+
+impl Into<LevelFilter> for Level {
+    fn into(self) -> LevelFilter {
+        match self {
+            Self::Off => LevelFilter::Off,
+            Self::Error => LevelFilter::Error,
+            Self::Warn => LevelFilter::Warn,
+            Self::Info => LevelFilter::Info,
+            Self::Debug => LevelFilter::Debug,
+            Self::Trace => LevelFilter::Trace,
+        }
+    }
+}

--- a/crates/brace-cms-log/src/lib.rs
+++ b/crates/brace-cms-log/src/lib.rs
@@ -1,0 +1,54 @@
+use chrono::Local;
+use fern::colors::ColoredLevelConfig;
+use fern::{log_file, Dispatch, InitError};
+
+use brace_config::Config;
+
+use self::level::Level;
+use self::output::Output;
+
+pub use log::{debug, error, info, log, trace, warn};
+
+pub mod level;
+pub mod output;
+
+pub fn init(config: &Config) -> Result<(), InitError> {
+    let level: Level = config.get("log.level").unwrap_or(Level::default());
+    let output: Output = config.get("log.output").unwrap_or(Output::default());
+    let mut logger = Dispatch::new();
+
+    logger = match output {
+        Output::File(_) => logger.format(move |out, message, record| {
+            out.finish(format_args!(
+                "[{} {} {}] {}",
+                Local::now().format("%Y-%m-%dT%H:%M:%SZ"),
+                record.level(),
+                record.target(),
+                message,
+            ))
+        }),
+        _ => {
+            let colors = ColoredLevelConfig::new();
+
+            logger.format(move |out, message, record| {
+                out.finish(format_args!(
+                    "[{} {} {}] {}",
+                    Local::now().format("%Y-%m-%dT%H:%M:%SZ"),
+                    colors.color(record.level()),
+                    record.target(),
+                    message,
+                ))
+            })
+        }
+    };
+
+    logger = logger.level(level.into());
+    logger = match output {
+        Output::Stdout => logger.chain(std::io::stdout()),
+        Output::Stderr => logger.chain(std::io::stderr()),
+        Output::File(file) => logger.chain(log_file(file)?),
+    };
+    logger.apply()?;
+
+    Ok(())
+}

--- a/crates/brace-cms-log/src/lib.rs
+++ b/crates/brace-cms-log/src/lib.rs
@@ -13,8 +13,8 @@ pub mod level;
 pub mod output;
 
 pub fn init(config: &Config) -> Result<(), InitError> {
-    let level: Level = config.get("log.level").unwrap_or(Level::default());
-    let output: Output = config.get("log.output").unwrap_or(Output::default());
+    let level: Level = config.get("log.level").unwrap_or_default();
+    let output: Output = config.get("log.output").unwrap_or_default();
     let mut logger = Dispatch::new();
 
     logger = match output {

--- a/crates/brace-cms-log/src/output.rs
+++ b/crates/brace-cms-log/src/output.rs
@@ -1,0 +1,68 @@
+use std::fmt::{self, Display};
+use std::path::PathBuf;
+
+use serde::de::{Deserialize, Deserializer, Visitor};
+use serde::ser::{Serialize, Serializer};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Output {
+    Stdout,
+    Stderr,
+    File(PathBuf),
+}
+
+impl Default for Output {
+    fn default() -> Self {
+        Self::Stdout
+    }
+}
+
+impl Display for Output {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Stdout => write!(f, "stdout"),
+            Self::Stderr => write!(f, "stderr"),
+            Self::File(file) => write!(f, "{:?}", file),
+        }
+    }
+}
+
+impl Serialize for Output {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Stdout => serializer.serialize_unit_variant("Output", 0, "stdout"),
+            Self::Stderr => serializer.serialize_unit_variant("Output", 1, "stderr"),
+            Self::File(file) => serializer.serialize_str(&format!("{}", file.display())),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Output {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        pub struct OutputVisitor;
+
+        impl<'de> Visitor<'de> for OutputVisitor {
+            type Value = Output;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("stdout, stderr or file path")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+                match value {
+                    "stdout" => Ok(Output::Stdout),
+                    "stderr" => Ok(Output::Stderr),
+                    file => Ok(Output::File(file.into())),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(OutputVisitor)
+    }
+}

--- a/crates/brace-cms/Cargo.toml
+++ b/crates/brace-cms/Cargo.toml
@@ -16,6 +16,7 @@ dev = ["listenfd"]
 
 [dependencies]
 actix-rt = "1.0"
+brace-cms-log = { path = "../brace-cms-log" }
 brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", features = ["toml"], default_features = false }
 brace-web = { git = "https://github.com/brace-rs/brace-web", rev = "dd0cee2e916553594acb8270632b5727474db01f" }
 listenfd = { version = "0.3", optional = true }

--- a/crates/brace-cms/tests/fixtures/config.toml
+++ b/crates/brace-cms/tests/fixtures/config.toml
@@ -1,3 +1,6 @@
 [server]
 host = "127.0.0.1"
 port = 65080
+
+[log]
+level = "off"


### PR DESCRIPTION
This adds a new crate to handle the setup of logging with the option to log to stdout, stderr or to a file depending on the configuration.