### PR TITLE
Split server out to separate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
   "crates/brace-cms",
   "crates/brace-cms-log",
+  "crates/brace-cms-server",
   "crates/brace-cms-store-postgres",
 ]

--- a/crates/brace-cms-server/Cargo.toml
+++ b/crates/brace-cms-server/Cargo.toml
@@ -1,25 +1,21 @@
 [package]
-name = "brace-cms"
+name = "brace-cms-server"
 version = "0.1.0"
 authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
-description = "The brace content management system framework."
+description = "The brace content management system server."
 repository = "https://github.com/brace-rs/brace-cms"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [features]
 default = []
-dev = ["brace-cms-server/dev"]
+dev = ["listenfd"]
 
 [dependencies]
-actix-rt = "1.0"
-brace-cms-log = { path = "../brace-cms-log" }
-brace-cms-server = { path = "../brace-cms-server" }
+brace-cms-store-postgres = { path = "../brace-cms-store-postgres" }
 brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", features = ["toml"], default_features = false }
+brace-web = { git = "https://github.com/brace-rs/brace-web", rev = "dd0cee2e916553594acb8270632b5727474db01f" }
+listenfd = { version = "0.3", optional = true }
 
 [dev-dependencies]
-assert_cmd = "1.0"
-awc = "1.0"
-
-[[bin]]
-name = "brace-cms"
+actix-rt = "1.0"

--- a/crates/brace-cms-server/src/routes/index.rs
+++ b/crates/brace-cms-server/src/routes/index.rs
@@ -1,0 +1,22 @@
+use brace_web::core::HttpResponse;
+
+pub async fn get() -> HttpResponse {
+    HttpResponse::Ok().body("Hello world")
+}
+
+#[cfg(test)]
+mod tests {
+    use brace_web::core::test::{call_service, init_service, TestRequest};
+    use brace_web::core::{web, App};
+
+    use super::get;
+
+    #[actix_rt::test]
+    async fn test_server_index_get() {
+        let mut app = init_service(App::new().route("/", web::get().to(get))).await;
+        let req = TestRequest::with_header("content-type", "text/plain").to_request();
+        let res = call_service(&mut app, req).await;
+
+        assert!(res.status().is_success());
+    }
+}

--- a/crates/brace-cms-server/src/routes/mod.rs
+++ b/crates/brace-cms-server/src/routes/mod.rs
@@ -1,0 +1,1 @@
+pub mod index;

--- a/crates/brace-cms/src/bin/brace-cms/main.rs
+++ b/crates/brace-cms/src/bin/brace-cms/main.rs
@@ -1,11 +1,13 @@
 use std::io;
 
-use brace_cms::server;
+use brace_cms::server::server;
 use brace_config::Config;
 
 #[actix_rt::main]
 async fn main() -> io::Result<()> {
     let config = Config::load("config.toml").unwrap_or_else(|_| Config::new());
+
+    brace_cms::log::init(&config).unwrap();
 
     server(config).await
 }

--- a/crates/brace-cms/src/lib.rs
+++ b/crates/brace-cms/src/lib.rs
@@ -1,0 +1,2 @@
+pub use brace_cms_log as log;
+pub use brace_cms_server as server;


### PR DESCRIPTION
This moves the server to a separate crate as not all content management systems require a web server. This also removes the server's dependency on the log crate by leaving it at the root.