### PR TITLE
Add core crate for common components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/brace-cms",
+  "crates/brace-cms-core",
   "crates/brace-cms-log",
   "crates/brace-cms-server",
   "crates/brace-cms-store-postgres",

--- a/crates/brace-cms-core/Cargo.toml
+++ b/crates/brace-cms-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "brace-cms-core"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "The brace content management system core."
+repository = "https://github.com/brace-rs/brace-cms"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]
+brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "8f4dd5a4803ef23ea8cec4092b8a40e9a19ce8bb", features = ["toml"], default_features = false }

--- a/crates/brace-cms-core/src/lib.rs
+++ b/crates/brace-cms-core/src/lib.rs
@@ -1,0 +1,1 @@
+pub use brace_config as config;

--- a/crates/brace-cms-log/Cargo.toml
+++ b/crates/brace-cms-log/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", default_features = false }
+brace-cms-core = { path = "../brace-cms-core" }
 chrono = "0.4"
 fern = { version = "0.6", features = ["colored"] }
 log = "0.4"

--- a/crates/brace-cms-log/src/lib.rs
+++ b/crates/brace-cms-log/src/lib.rs
@@ -2,7 +2,7 @@ use chrono::Local;
 use fern::colors::ColoredLevelConfig;
 use fern::{log_file, Dispatch, InitError};
 
-use brace_config::Config;
+use brace_cms_core::config::Config;
 
 use self::level::Level;
 use self::output::Output;

--- a/crates/brace-cms-server/Cargo.toml
+++ b/crates/brace-cms-server/Cargo.toml
@@ -12,8 +12,8 @@ default = []
 dev = ["listenfd"]
 
 [dependencies]
+brace-cms-core = { path = "../brace-cms-core" }
 brace-cms-store-postgres = { path = "../brace-cms-store-postgres" }
-brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", features = ["toml"], default_features = false }
 brace-web = { git = "https://github.com/brace-rs/brace-web", rev = "dd0cee2e916553594acb8270632b5727474db01f" }
 listenfd = { version = "0.3", optional = true }
 

--- a/crates/brace-cms-server/src/lib.rs
+++ b/crates/brace-cms-server/src/lib.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::net::Ipv4Addr;
 
-use brace_config::Config;
+use brace_cms_core::config::Config;
 use brace_web::core::middleware::Logger;
 use brace_web::core::{web, App, HttpServer};
 

--- a/crates/brace-cms-store-postgres/Cargo.toml
+++ b/crates/brace-cms-store-postgres/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", default_features = false }
+brace-cms-core = { path = "../brace-cms-core" }
 brace-data-store-postgres = { git = "https://github.com/brace-rs/brace-data", rev = "50592b806e748d922cd0461abbdcb1a2bb0e2062" }
 brace-web-core = { git = "https://github.com/brace-rs/brace-web", rev = "dd0cee2e916553594acb8270632b5727474db01f" }
 futures = "0.3"

--- a/crates/brace-cms-store-postgres/src/config.rs
+++ b/crates/brace-cms-store-postgres/src/config.rs
@@ -4,7 +4,7 @@ use brace_data_store_postgres::{Config as PostgresConfig, Error as PostgresError
 use brace_web_core::web::{self, Data, ServiceConfig};
 use brace_web_core::{Error, HttpResponse};
 
-use brace_config::Config;
+use brace_cms_core::config::Config;
 
 pub async fn configure(config: &Config) -> impl Fn(&mut ServiceConfig) + Clone {
     let mut postgres_config = PostgresConfig::new();

--- a/crates/brace-cms/Cargo.toml
+++ b/crates/brace-cms/Cargo.toml
@@ -13,9 +13,9 @@ dev = ["brace-cms-server/dev"]
 
 [dependencies]
 actix-rt = "1.0"
+brace-cms-core = { path = "../brace-cms-core" }
 brace-cms-log = { path = "../brace-cms-log" }
 brace-cms-server = { path = "../brace-cms-server" }
-brace-config = { git = "https://github.com/brace-rs/brace-config", rev = "da563f455a8d4e98d90dc2f27c639ea789f078c2", features = ["toml"], default_features = false }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/crates/brace-cms/src/bin/brace-cms/main.rs
+++ b/crates/brace-cms/src/bin/brace-cms/main.rs
@@ -1,7 +1,7 @@
 use std::io;
 
+use brace_cms::core::config::Config;
 use brace_cms::server::server;
-use brace_config::Config;
 
 #[actix_rt::main]
 async fn main() -> io::Result<()> {

--- a/crates/brace-cms/src/lib.rs
+++ b/crates/brace-cms/src/lib.rs
@@ -1,2 +1,3 @@
+pub use brace_cms_core as core;
 pub use brace_cms_log as log;
 pub use brace_cms_server as server;


### PR DESCRIPTION
This introduces the `core` crate for common components. Currently it does nothing more than re-export the `brace-config` crate but it will soon have a bigger purpose. This will help manage dependencies on commonly used unreleased crates where commit SHAs may become out of sync.