### PR TITLE
Add store crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
   "crates/brace-cms-core",
   "crates/brace-cms-logger",
   "crates/brace-cms-server",
+  "crates/brace-cms-store",
   "crates/brace-cms-store-postgres",
 ]

--- a/crates/brace-cms-server/Cargo.toml
+++ b/crates/brace-cms-server/Cargo.toml
@@ -13,7 +13,7 @@ dev = ["listenfd"]
 
 [dependencies]
 brace-cms-core = { path = "../brace-cms-core" }
-brace-cms-store-postgres = { path = "../brace-cms-store-postgres" }
+brace-cms-store = { path = "../brace-cms-store" }
 brace-web = { git = "https://github.com/brace-rs/brace-web", rev = "dd0cee2e916553594acb8270632b5727474db01f" }
 listenfd = { version = "0.3", optional = true }
 

--- a/crates/brace-cms-server/src/lib.rs
+++ b/crates/brace-cms-server/src/lib.rs
@@ -15,7 +15,7 @@ pub async fn server(config: Config) -> io::Result<()> {
     let addr = format!("{}:{}", host, port);
     let format = r#"%a "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#;
 
-    let postgres = brace_cms_store_postgres::configure(&config).await;
+    let postgres = brace_cms_store::postgres::configure(&config).await;
 
     let mut server = HttpServer::new(move || {
         App::new()

--- a/crates/brace-cms-store-postgres/Cargo.toml
+++ b/crates/brace-cms-store-postgres/Cargo.toml
@@ -2,7 +2,7 @@
 name = "brace-cms-store-postgres"
 version = "0.1.0"
 authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
-description = "The postgres data store integration."
+description = "The brace content management system store postgres integration."
 repository = "https://github.com/brace-rs/brace-cms"
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/crates/brace-cms-store/Cargo.toml
+++ b/crates/brace-cms-store/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "brace-cms-store"
+version = "0.1.0"
+authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
+description = "The brace content management system store."
+repository = "https://github.com/brace-rs/brace-cms"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]
+brace-cms-store-postgres = { path = "../brace-cms-store-postgres" }

--- a/crates/brace-cms-store/src/lib.rs
+++ b/crates/brace-cms-store/src/lib.rs
@@ -1,0 +1,1 @@
+pub use brace_cms_store_postgres as postgres;

--- a/crates/brace-cms/Cargo.toml
+++ b/crates/brace-cms/Cargo.toml
@@ -16,6 +16,7 @@ actix-rt = "1.0"
 brace-cms-core = { path = "../brace-cms-core" }
 brace-cms-logger = { path = "../brace-cms-logger" }
 brace-cms-server = { path = "../brace-cms-server" }
+brace-cms-store = { path = "../brace-cms-store" }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/crates/brace-cms/src/lib.rs
+++ b/crates/brace-cms/src/lib.rs
@@ -1,3 +1,4 @@
 pub use brace_cms_core as core;
 pub use brace_cms_logger as logger;
 pub use brace_cms_server as server;
+pub use brace_cms_store as store;


### PR DESCRIPTION
This adds a new store crate to re-export the postgres crate. This is intended to allow multiple store integrations at some point in the future.